### PR TITLE
Add adapters for go-kit metrics and a factory for expvar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
 language: go
 
 go:
-  - 1.6
   - 1.7
 
 env:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9f290d9e15fd4ca2a156d85c4a14b7980695cbc433d998ad580c6b03957d50e1
-updated: 2017-02-08T22:11:35.491490138-05:00
+hash: b2df3ac611e65c63f6a20f87b6333b3199cb774fbd70c6aecbc6cae20041e565
+updated: 2017-02-08T22:54:23.683077422-05:00
 imports:
 - name: github.com/codahale/hdrhistogram
   version: f8ad88b59a584afeee9d334eff879b104439117b

--- a/glide.lock
+++ b/glide.lock
@@ -1,11 +1,28 @@
-hash: 5a477cf0a2003a589c40096fb4f0d0ba64bceca29493cb5e55e105a5f1784204
-updated: 2016-10-17T14:37:10.287473292-04:00
+hash: 9f290d9e15fd4ca2a156d85c4a14b7980695cbc433d998ad580c6b03957d50e1
+updated: 2017-02-08T22:11:35.491490138-05:00
 imports:
 - name: github.com/codahale/hdrhistogram
-  version: 5fd85ec0b4e2dd5d4158d257d943f2e586d86b62
-testImports:
+  version: f8ad88b59a584afeee9d334eff879b104439117b
+- name: github.com/davecgh/go-spew
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  subpackages:
+  - spew
+- name: github.com/go-kit/kit
+  version: 414b9e6bc6c6848e6058611c56ad9d1216af3653
+  subpackages:
+  - metrics
+  - metrics/expvar
+  - metrics/generic
+  - metrics/internal/lv
+- name: github.com/pmezard/go-difflib
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  subpackages:
+  - difflib
 - name: github.com/stretchr/testify
-  version: 089c7181b8c728499929ff09b62d3fdd8df8adff
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - require
+- name: github.com/VividCortex/gohistogram
+  version: 51564d9861991fb0ad0f531c99ef602d0f9866e6
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,3 +1,7 @@
 package: github.com/uber/jaeger-lib
 import:
 - package: github.com/codahale/hdrhistogram
+- package: github.com/go-kit/kit
+  subpackages:
+testImports:
+- package: github.com/stretchr/testify

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,5 @@ package: github.com/uber/jaeger-lib
 import:
 - package: github.com/codahale/hdrhistogram
 - package: github.com/go-kit/kit
-  subpackages:
 testImport:
 - package: github.com/stretchr/testify

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,5 +3,5 @@ import:
 - package: github.com/codahale/hdrhistogram
 - package: github.com/go-kit/kit
   subpackages:
-testImports:
+testImport:
 - package: github.com/stretchr/testify

--- a/metrics/counter.go
+++ b/metrics/counter.go
@@ -22,7 +22,7 @@ package metrics
 
 // Counter tracks the number of times an event has occurred
 type Counter interface {
-	// Add adds the given value to the counter.
+	// Inc adds the given value to the counter.
 	Inc(int64)
 }
 

--- a/metrics/go-kit/expvar/factory.go
+++ b/metrics/go-kit/expvar/factory.go
@@ -1,0 +1,48 @@
+package expvar
+
+import (
+	kit "github.com/go-kit/kit/metrics/expvar"
+
+	"github.com/uber/jaeger-lib/metrics"
+	xkit "github.com/uber/jaeger-lib/metrics/go-kit"
+)
+
+// NewFactory creates a new metrics factory using go-kit expvar package.
+// scope is the name that will be prepended to the names of all metrics
+// created by this factory. buckets is the number of buckets to be used
+// in histograms representing timers.
+func NewFactory(scope string, buckets int) metrics.Factory {
+	return factory{
+		scope:   scope,
+		buckets: buckets,
+	}
+}
+
+type factory struct {
+	scope   string
+	buckets int
+}
+
+func (f factory) subScope(name string) string {
+	return f.scope + "_" + name
+}
+
+func (f factory) Counter(name string, tags map[string]string) metrics.Counter {
+	return xkit.NewCounter(kit.NewCounter(f.subScope(name)))
+}
+
+func (f factory) Timer(name string, tags map[string]string) metrics.Timer {
+	return xkit.NewTimer(kit.NewHistogram(f.subScope(name), f.buckets))
+}
+
+func (f factory) Gauge(name string, tags map[string]string) metrics.Gauge {
+	return xkit.NewGauge(kit.NewGauge(f.subScope(name)))
+}
+
+// Namespace is a no-op for expvar, since i
+func (f factory) Namespace(name string, tags map[string]string) metrics.Factory {
+	return factory{
+		scope:   f.subScope(name),
+		buckets: f.buckets,
+	}
+}

--- a/metrics/go-kit/expvar/factory.go
+++ b/metrics/go-kit/expvar/factory.go
@@ -1,48 +1,32 @@
 package expvar
 
 import (
-	kit "github.com/go-kit/kit/metrics/expvar"
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/expvar"
 
-	"github.com/uber/jaeger-lib/metrics"
-	xkit "github.com/uber/jaeger-lib/metrics/go-kit"
+	"github.com/uber/jaeger-lib/metrics/go-kit"
 )
 
 // NewFactory creates a new metrics factory using go-kit expvar package.
-// scope is the name that will be prepended to the names of all metrics
-// created by this factory. buckets is the number of buckets to be used
-// in histograms representing timers.
-func NewFactory(scope string, buckets int) metrics.Factory {
+// buckets is the number of buckets to be used in histograms.
+func NewFactory(buckets int) xkit.Factory {
 	return factory{
-		scope:   scope,
 		buckets: buckets,
 	}
 }
 
 type factory struct {
-	scope   string
 	buckets int
 }
 
-func (f factory) subScope(name string) string {
-	return f.scope + "_" + name
+func (f factory) Counter(name string) metrics.Counter {
+	return expvar.NewCounter(name)
 }
 
-func (f factory) Counter(name string, tags map[string]string) metrics.Counter {
-	return xkit.NewCounter(kit.NewCounter(f.subScope(name)))
+func (f factory) Histogram(name string) metrics.Histogram {
+	return expvar.NewHistogram(name, f.buckets)
 }
 
-func (f factory) Timer(name string, tags map[string]string) metrics.Timer {
-	return xkit.NewTimer(kit.NewHistogram(f.subScope(name), f.buckets))
-}
-
-func (f factory) Gauge(name string, tags map[string]string) metrics.Gauge {
-	return xkit.NewGauge(kit.NewGauge(f.subScope(name)))
-}
-
-// Namespace is a no-op for expvar, since i
-func (f factory) Namespace(name string, tags map[string]string) metrics.Factory {
-	return factory{
-		scope:   f.subScope(name),
-		buckets: f.buckets,
-	}
+func (f factory) Gauge(name string) metrics.Gauge {
+	return expvar.NewGauge(name)
 }

--- a/metrics/go-kit/expvar/factory_test.go
+++ b/metrics/go-kit/expvar/factory_test.go
@@ -1,0 +1,52 @@
+package expvar
+
+import (
+	"expvar"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCounter(t *testing.T) {
+	f := NewFactory("gokit_expvar", 10)
+	c := f.Counter("counter", nil)
+	c.Inc(42)
+	kv := findExpvar("gokit_expvar_counter")
+	assert.Equal(t, "42", kv.Value.String())
+}
+
+func TestGauge(t *testing.T) {
+	f := NewFactory("gokit_expvar", 10)
+	g := f.Gauge("gauge", nil)
+	g.Update(42)
+	kv := findExpvar("gokit_expvar_gauge")
+	assert.Equal(t, "42", kv.Value.String())
+}
+
+func TestTimer(t *testing.T) {
+	f := NewFactory("gokit_expvar", 10)
+	timer := f.Timer("timer", nil)
+	timer.Record(100*time.Millisecond + 500*time.Microsecond)
+	kv := findExpvar("gokit_expvar_timer.p50")
+	assert.Equal(t, "100.5", kv.Value.String())
+}
+
+func TestNamespace(t *testing.T) {
+	f := NewFactory("gokit_expvar", 10)
+	f = f.Namespace("namespace", nil)
+	c := f.Counter("counter", nil)
+	c.Inc(42)
+	kv := findExpvar("gokit_expvar_namespace_counter")
+	assert.Equal(t, "42", kv.Value.String())
+}
+
+func findExpvar(key string) *expvar.KeyValue {
+	var kv *expvar.KeyValue
+	expvar.Do(func(v expvar.KeyValue) {
+		if v.Key == key {
+			kv = &v
+		}
+	})
+	return kv
+}

--- a/metrics/go-kit/expvar/factory_test.go
+++ b/metrics/go-kit/expvar/factory_test.go
@@ -29,7 +29,7 @@ func TestTimer(t *testing.T) {
 	timer := f.Timer("timer", nil)
 	timer.Record(100*time.Millisecond + 500*time.Microsecond)
 	kv := findExpvar("gokit_expvar_timer.p50")
-	assert.Equal(t, "100.5", kv.Value.String())
+	assert.Equal(t, "0.1005", kv.Value.String())
 }
 
 func TestNamespace(t *testing.T) {

--- a/metrics/go-kit/expvar/factory_test.go
+++ b/metrics/go-kit/expvar/factory_test.go
@@ -3,42 +3,32 @@ package expvar
 import (
 	"expvar"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCounter(t *testing.T) {
-	f := NewFactory("gokit_expvar", 10)
-	c := f.Counter("counter", nil)
-	c.Inc(42)
+	f := NewFactory(10)
+	c := f.Counter("gokit_expvar_counter")
+	c.Add(42)
 	kv := findExpvar("gokit_expvar_counter")
 	assert.Equal(t, "42", kv.Value.String())
 }
 
 func TestGauge(t *testing.T) {
-	f := NewFactory("gokit_expvar", 10)
-	g := f.Gauge("gauge", nil)
-	g.Update(42)
+	f := NewFactory(10)
+	g := f.Gauge("gokit_expvar_gauge")
+	g.Set(42)
 	kv := findExpvar("gokit_expvar_gauge")
 	assert.Equal(t, "42", kv.Value.String())
 }
 
-func TestTimer(t *testing.T) {
-	f := NewFactory("gokit_expvar", 10)
-	timer := f.Timer("timer", nil)
-	timer.Record(100*time.Millisecond + 500*time.Microsecond)
-	kv := findExpvar("gokit_expvar_timer.p50")
-	assert.Equal(t, "0.1005", kv.Value.String())
-}
-
-func TestNamespace(t *testing.T) {
-	f := NewFactory("gokit_expvar", 10)
-	f = f.Namespace("namespace", nil)
-	c := f.Counter("counter", nil)
-	c.Inc(42)
-	kv := findExpvar("gokit_expvar_namespace_counter")
-	assert.Equal(t, "42", kv.Value.String())
+func TestHistogram(t *testing.T) {
+	f := NewFactory(10)
+	hist := f.Histogram("gokit_expvar_hist")
+	hist.Observe(10.5)
+	kv := findExpvar("gokit_expvar_hist.p50")
+	assert.Equal(t, "10.5", kv.Value.String())
 }
 
 func findExpvar(key string) *expvar.KeyValue {

--- a/metrics/go-kit/factory.go
+++ b/metrics/go-kit/factory.go
@@ -1,0 +1,94 @@
+package xkit
+
+import (
+	kit "github.com/go-kit/kit/metrics"
+
+	"github.com/uber/jaeger-lib/metrics"
+)
+
+// Factory provides a unified interface for creating named metrics
+// from various go-kit metrics implementations.
+type Factory interface {
+	Counter(name string) kit.Counter
+	Gauge(name string) kit.Gauge
+	Histogram(name string) kit.Histogram
+}
+
+// Wrap is used to create an adapter from xkit.Factory to metrics.Factory.
+func Wrap(namespace string, f Factory) metrics.Factory {
+	return &factory{
+		scope:   namespace,
+		factory: f,
+	}
+}
+
+type factory struct {
+	scope   string
+	tags    map[string]string
+	factory Factory
+}
+
+func (f *factory) subScope(name string) string {
+	if f.scope == "" {
+		return name
+	}
+	if name == "" {
+		return f.scope
+	}
+	return f.scope + "." + name
+}
+
+func (f *factory) Counter(name string, tags map[string]string) metrics.Counter {
+	counter := f.factory.Counter(f.subScope(name))
+	tagsList := f.tagsList(tags)
+	if len(tagsList) > 0 {
+		counter = counter.With(tagsList...)
+	}
+	return NewCounter(counter)
+}
+
+func (f *factory) Timer(name string, tags map[string]string) metrics.Timer {
+	hist := f.factory.Histogram(f.subScope(name))
+	tagsList := f.tagsList(tags)
+	if len(tagsList) > 0 {
+		hist = hist.With(tagsList...)
+	}
+	return NewTimer(hist)
+}
+
+func (f *factory) Gauge(name string, tags map[string]string) metrics.Gauge {
+	gauge := f.factory.Gauge(f.subScope(name))
+	tagsList := f.tagsList(tags)
+	if len(tagsList) > 0 {
+		gauge = gauge.With(tagsList...)
+	}
+	return NewGauge(gauge)
+}
+
+func (f *factory) Namespace(name string, tags map[string]string) metrics.Factory {
+	return &factory{
+		scope:   f.subScope(name),
+		tags:    f.mergeTags(tags),
+		factory: f.factory,
+	}
+}
+
+func (f *factory) tagsList(a map[string]string) []string {
+	m := f.mergeTags(a)
+	ret := make([]string, 0, 2*len(m))
+	for k, v := range m {
+		ret = append(ret, k, v)
+	}
+	return ret
+}
+
+func (f *factory) mergeTags(tags map[string]string) map[string]string {
+	ret := make(map[string]string, len(f.tags)+len(tags))
+	for k, v := range f.tags {
+		ret[k] = v
+	}
+	for k, v := range tags {
+		ret[k] = v
+	}
+	return ret
+}

--- a/metrics/go-kit/factory_test.go
+++ b/metrics/go-kit/factory_test.go
@@ -1,0 +1,116 @@
+package xkit
+
+import (
+	"testing"
+	"time"
+
+	kit "github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/generic"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/jaeger-lib/metrics"
+)
+
+type genericFactory struct{}
+
+func (f genericFactory) Counter(name string) kit.Counter     { return generic.NewCounter(name) }
+func (f genericFactory) Gauge(name string) kit.Gauge         { return generic.NewGauge(name) }
+func (f genericFactory) Histogram(name string) kit.Histogram { return generic.NewHistogram(name, 10) }
+
+type Tags map[string]string
+type metricFunc func(t *testing.T, testCase testCase, f metrics.Factory) (name func() string, labels func() []string)
+
+type testCase struct {
+	prefix string
+	name   string
+	tags   Tags
+
+	useNamespace  bool
+	namespace     string
+	namespaceTags Tags
+
+	expName string
+	expTags []string
+}
+
+func TestFactoryScoping(t *testing.T) {
+	testSuites := []struct {
+		metricType string
+		metricFunc metricFunc
+	}{
+		{"counter", testCounter},
+		{"gauge", testGauge},
+		{"timer", testTimer},
+	}
+	for _, ts := range testSuites {
+		testSuite := ts // capture loop var
+		testCases := []testCase{
+			{prefix: "x", name: "", expName: "x"},
+			{prefix: "", name: "y", expName: "y"},
+			{prefix: "x", name: "y", expName: "x.y"},
+			{prefix: "x", name: "z", expName: "x.z", tags: Tags{"a": "b"}, expTags: []string{"a", "b"}},
+			{
+				name:         "y",
+				useNamespace: true,
+				namespace:    "z",
+				expName:      "z.y",
+			},
+			{
+				name:          "y",
+				useNamespace:  true,
+				namespace:     "w",
+				namespaceTags: Tags{"a": "b"},
+				expName:       "w.y",
+				expTags:       []string{"a", "b"},
+			},
+		}
+		for _, tc := range testCases {
+			testCase := tc // capture loop var
+			t.Run(testSuite.metricType+":"+testCase.expName, func(t *testing.T) {
+				f := Wrap(testCase.prefix, genericFactory{})
+				if testCase.useNamespace {
+					f = f.Namespace(testCase.namespace, testCase.namespaceTags)
+				}
+				name, labels := testSuite.metricFunc(t, testCase, f)
+				if testCase.tags == nil && testCase.namespaceTags == nil {
+					// TODO go-kit loses the name of the counter on With()
+					// https://github.com/go-kit/kit/issues/455
+					assert.Equal(t, testCase.expName, name())
+				}
+				if testCase.expTags != nil {
+					assert.Equal(t, testCase.expTags, labels())
+				}
+			})
+		}
+	}
+}
+
+func testCounter(t *testing.T, testCase testCase, f metrics.Factory) (name func() string, labels func() []string) {
+	c := f.Counter(testCase.name, testCase.tags)
+	c.Inc(123)
+	gc := c.(*Counter).counter.(*generic.Counter)
+	assert.EqualValues(t, 123.0, gc.Value())
+	name = func() string { return gc.Name }
+	labels = gc.LabelValues
+	return
+}
+
+func testGauge(t *testing.T, testCase testCase, f metrics.Factory) (name func() string, labels func() []string) {
+	g := f.Gauge(testCase.name, testCase.tags)
+	g.Update(123)
+	gg := g.(*Gauge).gauge.(*generic.Gauge)
+	assert.EqualValues(t, 123.0, gg.Value())
+	name = func() string { return gg.Name }
+	labels = gg.LabelValues
+	return
+}
+
+func testTimer(t *testing.T, testCase testCase, f metrics.Factory) (name func() string, labels func() []string) {
+	tm := f.Timer(testCase.name, testCase.tags)
+	tm.Record(123 * time.Millisecond)
+	gt := tm.(*Timer).hist.(*generic.Histogram)
+	assert.InDelta(t, 0.123, gt.Quantile(0.9), 0.00001)
+	name = func() string { return gt.Name }
+	labels = gt.LabelValues
+	return
+}

--- a/metrics/go-kit/metrics.go
+++ b/metrics/go-kit/metrics.go
@@ -1,0 +1,53 @@
+package xkit
+
+import (
+	"time"
+
+	kit "github.com/go-kit/kit/metrics"
+)
+
+// Counter is an adapter from go-kit Counter to jaeger-lib Counter
+type Counter struct {
+	counter kit.Counter
+}
+
+// NewCounter creates a new Counter
+func NewCounter(counter kit.Counter) *Counter {
+	return &Counter{counter: counter}
+}
+
+// Inc adds the given value to the counter.
+func (c *Counter) Inc(delta int64) {
+	c.counter.Add(float64(delta))
+}
+
+// Gauge is an adapter from go-kit Gauge to jaeger-lib Gauge
+type Gauge struct {
+	gauge kit.Gauge
+}
+
+// NewGauge creates a new Gauge
+func NewGauge(gauge kit.Gauge) *Gauge {
+	return &Gauge{gauge: gauge}
+}
+
+// Update the gauge to the value passed in.
+func (g *Gauge) Update(value int64) {
+	g.gauge.Set(float64(value))
+}
+
+// Timer is an adapter from go-kit Histogram to jaeger-lib Timer
+type Timer struct {
+	hist kit.Histogram
+}
+
+// NewTimer creates a new Timer
+func NewTimer(hist kit.Histogram) *Timer {
+	return &Timer{hist: hist}
+}
+
+// Record saves the time passed in.
+func (t *Timer) Record(delta time.Duration) {
+	millis := float64(delta) / float64(time.Millisecond)
+	t.hist.Observe(millis)
+}

--- a/metrics/go-kit/metrics.go
+++ b/metrics/go-kit/metrics.go
@@ -48,6 +48,5 @@ func NewTimer(hist kit.Histogram) *Timer {
 
 // Record saves the time passed in.
 func (t *Timer) Record(delta time.Duration) {
-	millis := float64(delta) / float64(time.Millisecond)
-	t.hist.Observe(millis)
+	t.hist.Observe(delta.Seconds())
 }

--- a/metrics/go-kit/metrics_test.go
+++ b/metrics/go-kit/metrics_test.go
@@ -28,5 +28,5 @@ func TestTimer(t *testing.T) {
 	kitHist := generic.NewHistogram("abc", 10)
 	var timer metrics.Timer = NewTimer(kitHist)
 	timer.Record(100*time.Millisecond + 500*time.Microsecond) // 100.5 milliseconds
-	assert.EqualValues(t, 100.5, kitHist.Quantile(0.9))
+	assert.EqualValues(t, 0.1005, kitHist.Quantile(0.9))
 }

--- a/metrics/go-kit/metrics_test.go
+++ b/metrics/go-kit/metrics_test.go
@@ -1,0 +1,32 @@
+package xkit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/metrics/generic"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/jaeger-lib/metrics"
+)
+
+func TestCounter(t *testing.T) {
+	kitCounter := generic.NewCounter("abc")
+	var counter metrics.Counter = NewCounter(kitCounter)
+	counter.Inc(123)
+	assert.EqualValues(t, 123, kitCounter.Value())
+}
+
+func TestGauge(t *testing.T) {
+	kitGauge := generic.NewGauge("abc")
+	var gauge metrics.Gauge = NewGauge(kitGauge)
+	gauge.Update(123)
+	assert.EqualValues(t, 123, kitGauge.Value())
+}
+
+func TestTimer(t *testing.T) {
+	kitHist := generic.NewHistogram("abc", 10)
+	var timer metrics.Timer = NewTimer(kitHist)
+	timer.Record(100*time.Millisecond + 500*time.Microsecond) // 100.5 milliseconds
+	assert.EqualValues(t, 100.5, kitHist.Quantile(0.9))
+}


### PR DESCRIPTION
This implements the pattern I was asking for in https://github.com/go-kit/kit/issues/378, simplified for our needs.