### PR TITLE
Allow jaeger-lib to be used with tally >= 2.1, < 4

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e6528321fbc04ff60802bf95b6e4f89b9273413f1f6468d2d8a6c2cc729aa15c
-updated: 2017-03-10T15:31:49.90064899-08:00
+hash: a2184b829a69a7e33880eacae5f0dc39be4e0f9dbbad074e19de83172e1ac135
+updated: 2017-04-17T18:09:23.149910885-07:00
 imports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
@@ -26,7 +26,7 @@ imports:
   - assert
   - require
 - name: github.com/uber-go/tally
-  version: 34be4a565ce6286a0ba91a54a81be3f6181ca2e2
+  version: 4b9d9de43ffcb0b7efe67dab2a92c2d58dbf16ab
 - name: github.com/VividCortex/gohistogram
   version: 51564d9861991fb0ad0f531c99ef602d0f9866e6
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: a2184b829a69a7e33880eacae5f0dc39be4e0f9dbbad074e19de83172e1ac135
-updated: 2017-04-17T18:09:23.149910885-07:00
+updated: 2017-04-19T09:43:59.295932552-07:00
 imports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,6 +4,6 @@ import:
 - package: github.com/go-kit/kit
   version: a5e3d03d36fa4f9f2915d10d6b17fa0e02b734cc
 - package: github.com/uber-go/tally
-  version: ^2.1.0
+  version: ">= 2.1.0, < 4"
 testImport:
 - package: github.com/stretchr/testify

--- a/metrics/tally/factory_test.go
+++ b/metrics/tally/factory_test.go
@@ -19,9 +19,24 @@ func TestFactory(t *testing.T) {
 	timer := factory.Timer("timer", map[string]string{"x": "y"})
 	timer.Record(42 * time.Millisecond)
 	snapshot := testScope.Snapshot()
+
+	// tally v3 includes tags in the name, so look
 	c := snapshot.Counters()["pre.fix.counter"]
+	if c == nil {
+		// tally v3 includes tags in the name.
+		c = snapshot.Counters()["pre.fix.counter+a=b,c=d,x=y"]
+	}
+
 	g := snapshot.Gauges()["pre.fix.gauge"]
+	if g == nil {
+		g = snapshot.Gauges()["pre.fix.gauge+a=b,c=d,x=y"]
+	}
+
 	h := snapshot.Timers()["pre.fix.timer"]
+	if h == nil {
+		h = snapshot.Timers()["pre.fix.timer+a=b,c=d,x=y"]
+	}
+
 	expectedTags := map[string]string{"a": "b", "c": "d", "x": "y"}
 	assert.EqualValues(t, 42, c.Value())
 	assert.EqualValues(t, expectedTags, c.Tags())


### PR DESCRIPTION
This allows downstreams to use either tally v2.1 or the latest version (v3)