### PR TITLE
Allow overriding scope and tags separator

### DIFF
--- a/metrics/go-kit/factory.go
+++ b/metrics/go-kit/factory.go
@@ -35,20 +35,41 @@ type Factory interface {
 	Capabilities() Capabilities
 }
 
-// Capabilities describes capabilities of a specific metrics factory
+// Capabilities describes capabilities of a specific metrics factory.
 type Capabilities struct {
 	// Tagging indicates whether the factory has the capability for tagged metrics
 	Tagging bool
 }
 
+// FactoryOption is a function that adjusts some parameters of the factory.
+type FactoryOption func(*factory)
+
 // Wrap is used to create an adapter from xkit.Factory to metrics.Factory.
-func Wrap(namespace string, f Factory) metrics.Factory {
-	return &factory{
+func Wrap(namespace string, f Factory, options ...FactoryOption) metrics.Factory {
+	factory := &factory{
 		scope:    namespace,
 		factory:  f,
 		scopeSep: ".",
 		tagsSep:  ".",
 		tagKVSep: "_",
+	}
+	for i := range options {
+		options[i](factory)
+	}
+	return factory
+}
+
+// ScopeSeparator returns an option that overrides default scope separator.
+func ScopeSeparator(scopeSep string) FactoryOption {
+	return func(f *factory) {
+		f.scopeSep = scopeSep
+	}
+}
+
+// TagsSeparator returns an option that overrides default tags separator.
+func TagsSeparator(tagsSep string) FactoryOption {
+	return func(f *factory) {
+		f.tagsSep = tagsSep
 	}
 }
 
@@ -90,6 +111,7 @@ func (f *factory) nameAndTagsList(nom string, tags map[string]string) (name stri
 
 func (f *factory) Counter(name string, tags map[string]string) metrics.Counter {
 	name, tagsList := f.nameAndTagsList(name, tags)
+	println(name)
 	counter := f.factory.Counter(name)
 	if len(tagsList) > 0 {
 		counter = counter.With(tagsList...)

--- a/metrics/go-kit/factory.go
+++ b/metrics/go-kit/factory.go
@@ -111,7 +111,6 @@ func (f *factory) nameAndTagsList(nom string, tags map[string]string) (name stri
 
 func (f *factory) Counter(name string, tags map[string]string) metrics.Counter {
 	name, tagsList := f.nameAndTagsList(name, tags)
-	println(name)
 	counter := f.factory.Counter(name)
 	if len(tagsList) > 0 {
 		counter = counter.With(tagsList...)

--- a/metrics/go-kit/factory_test.go
+++ b/metrics/go-kit/factory_test.go
@@ -64,6 +64,7 @@ type testCase struct {
 	useNamespace  bool
 	namespace     string
 	namespaceTags Tags
+	options       []FactoryOption
 
 	expName string
 	expTags []string
@@ -134,12 +135,13 @@ func TestFactoryScoping(t *testing.T) {
 			},
 			{
 				f:             noTagsFactory,
+				options:       []FactoryOption{ScopeSeparator(":"), TagsSeparator(":")},
 				name:          "z",
 				tags:          Tags{"a": "b"},
 				useNamespace:  true,
 				namespace:     "w",
 				namespaceTags: Tags{"c": "d"},
-				expName:       "w.z.a_b.c_d",
+				expName:       "w:z:a_b:c_d",
 			},
 		}
 		for _, tc := range testCases {
@@ -149,7 +151,7 @@ func TestFactoryScoping(t *testing.T) {
 				factoryName = "noTagsFactory"
 			}
 			t.Run(factoryName+"_"+testSuite.metricType+"_"+testCase.expName, func(t *testing.T) {
-				f := Wrap(testCase.prefix, testCase.f)
+				f := Wrap(testCase.prefix, testCase.f, testCase.options...)
 				if testCase.useNamespace {
 					f = f.Namespace(testCase.namespace, testCase.namespaceTags)
 				}

--- a/metrics/go-kit/prometheus/factory_test.go
+++ b/metrics/go-kit/prometheus/factory_test.go
@@ -5,24 +5,25 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	xkit "github.com/uber/jaeger-lib/metrics/go-kit"
 )
 
 func TestCounter(t *testing.T) {
 	f := NewFactory("namespace", "subsystem", nil)
 	assert.True(t, f.Capabilities().Tagging)
-	c := f.Counter("gitkit_prom_counter")
+	c := f.Counter("gokit.prom-counter")
 	c.Add(42)
-	m := findMetric(t, "namespace_subsystem_gitkit_prom_counter")
+	m := findMetric(t, "namespace_subsystem_gokit_prom_counter")
 	require.NotNil(t, m)
 	assert.Equal(t, 42.0, m[0].GetCounter().GetValue())
 }
 
 func TestGauge(t *testing.T) {
 	f := NewFactory("namespace", "subsystem", nil)
-	g := f.Gauge("gokit_prom_gauge")
+	g := f.Gauge("gokit.prom-gauge")
 	g.Set(42)
 	m := findMetric(t, "namespace_subsystem_gokit_prom_gauge")
 	require.NotNil(t, m)
@@ -31,11 +32,24 @@ func TestGauge(t *testing.T) {
 
 func TestHistogram(t *testing.T) {
 	f := NewFactory("namespace", "subsystem", nil)
-	hist := f.Histogram("gokit_prom_hist")
+	hist := f.Histogram("gokit.prom-hist")
 	hist.Observe(10.5)
 	m := findMetric(t, "namespace_subsystem_gokit_prom_hist")
 	require.NotNil(t, m)
 	assert.Equal(t, 10.5, m[0].GetHistogram().GetSampleSum())
+}
+
+func TestWrapper(t *testing.T) {
+	f := NewFactory("", "", nil)
+	wf := xkit.Wrap("foo", f, xkit.ScopeSeparator(":"))
+	wf = wf.Namespace("bar", nil)
+	c := wf.Counter("gokit.prom-wrapped-counter", nil)
+	// TODO tags currently do not work because Prometheus requires to predeclate tag keys.
+	// c := wf.Counter("gokit.prom-wrapped-counter", map[string]string{"x": "y"})
+	c.Inc(42)
+	m := findMetric(t, "foo:bar:gokit_prom_wrapped_counter")
+	require.NotNil(t, m)
+	assert.Equal(t, 42.0, m[0].GetCounter().GetValue())
 }
 
 func findMetric(t *testing.T, key string) []*dto.Metric {


### PR DESCRIPTION
Prometheus does not allow '-' or '.' in metric names.

Cf: https://github.com/uber/jaeger/issues/273
