### PR TITLE
Support influx metrics

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 738f5ca57f397974e9aec8f89ae0fc7117ca866ade7ce839003002e7add1bd59
-updated: 2017-07-15T21:44:50.58044332-04:00
+hash: 8ca2ebd4305a4aaead18ee8cc5a84da42e95c202d53c1bd78d11436aeb8be8e4
+updated: 2017-09-12T23:48:13.239754093+02:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -8,7 +8,7 @@ imports:
 - name: github.com/codahale/hdrhistogram
   version: f8ad88b59a584afeee9d334eff879b104439117b
 - name: github.com/davecgh/go-spew
-  version: adab96458c51a58dc1783b3335dcce5461522e75
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
@@ -16,21 +16,35 @@ imports:
 - name: github.com/go-kit/kit
   version: a9ca6725cbbea455e61c6bc8a1ed28e81eb3493b
   subpackages:
+  - log
   - metrics
   - metrics/expvar
   - metrics/generic
+  - metrics/influx
   - metrics/internal/lv
   - metrics/prometheus
+- name: github.com/go-logfmt/logfmt
+  version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
+- name: github.com/go-stack/stack
+  version: 817915b46b97fd7bb80e8ab6b69f01a53ac3eebf
 - name: github.com/golang/protobuf
   version: 7cc19b78d562895b13596ddce7aafb59dd789318
   subpackages:
   - proto
+- name: github.com/influxdata/influxdb
+  version: f3f30726d822c4be8cd00137ba66b6e4fd68cca1
+  subpackages:
+  - client/v2
+  - models
+  - pkg/escape
+- name: github.com/kr/logfmt
+  version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/prometheus/client_golang
@@ -57,7 +71,7 @@ imports:
   - assert
   - require
 - name: github.com/uber-go/tally
-  version: 88e9c75b0cfc84139ad1bae3b7f123786cfd0770
+  version: be9e53c77349ae2dd4b8c03a6dc20ed9a88b9927
 - name: github.com/VividCortex/gohistogram
   version: 51564d9861991fb0ad0f531c99ef602d0f9866e6
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,8 +3,10 @@ import:
 - package: github.com/codahale/hdrhistogram
 - package: github.com/go-kit/kit
   version: v0.5.0
+  subpackages:
+  - metrics/influx
 - package: github.com/uber-go/tally
-  version: ">= 2.1.0, < 4"
+  version: '>= 2.1.0, < 4'
 - package: github.com/prometheus/client_golang
   version: v0.8.0
 testImport:

--- a/metrics/go-kit/influx/factory.go
+++ b/metrics/go-kit/influx/factory.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package influx
 
 import (

--- a/metrics/go-kit/influx/factory.go
+++ b/metrics/go-kit/influx/factory.go
@@ -29,7 +29,6 @@ func NewFactory(client *influx.Influx) xkit.Factory {
 }
 
 type factory struct {
-	buckets int
 	client  *influx.Influx
 }
 

--- a/metrics/go-kit/influx/factory.go
+++ b/metrics/go-kit/influx/factory.go
@@ -1,0 +1,35 @@
+package influx
+
+import (
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/influx"
+	"github.com/uber/jaeger-lib/metrics/go-kit"
+)
+
+// NewFactory creates a new metrics factory using go-kit influx package.
+func NewFactory(client *influx.Influx) xkit.Factory {
+	return factory{
+		client: client,
+	}
+}
+
+type factory struct {
+	buckets int
+	client *influx.Influx
+}
+
+func (f factory) Counter(name string) metrics.Counter {
+	return f.client.NewCounter(name)
+}
+
+func (f factory) Histogram(name string) metrics.Histogram {
+	return f.client.NewHistogram(name)
+}
+
+func (f factory) Gauge(name string) metrics.Gauge {
+	return f.client.NewGauge(name)
+}
+
+func (f factory) Capabilities() xkit.Capabilities {
+	return xkit.Capabilities{Tagging: true}
+}

--- a/metrics/go-kit/influx/factory.go
+++ b/metrics/go-kit/influx/factory.go
@@ -16,7 +16,7 @@ func NewFactory(client *influx.Influx) xkit.Factory {
 
 type factory struct {
 	buckets int
-	client *influx.Influx
+	client  *influx.Influx
 }
 
 func (f factory) Counter(name string) metrics.Counter {

--- a/metrics/go-kit/influx/factory.go
+++ b/metrics/go-kit/influx/factory.go
@@ -3,6 +3,7 @@ package influx
 import (
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/influx"
+
 	"github.com/uber/jaeger-lib/metrics/go-kit"
 )
 

--- a/metrics/go-kit/influx/factory.go
+++ b/metrics/go-kit/influx/factory.go
@@ -29,7 +29,7 @@ func NewFactory(client *influx.Influx) xkit.Factory {
 }
 
 type factory struct {
-	client  *influx.Influx
+	client *influx.Influx
 }
 
 func (f factory) Counter(name string) metrics.Counter {

--- a/metrics/go-kit/influx/factory_test.go
+++ b/metrics/go-kit/influx/factory_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/go-kit/kit/metrics/influx"
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/metrics/influx"
 	influxdb "github.com/influxdata/influxdb/client/v2"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/uber/jaeger-lib/metrics/go-kit"
 )

--- a/metrics/go-kit/influx/factory_test.go
+++ b/metrics/go-kit/influx/factory_test.go
@@ -1,0 +1,87 @@
+package influx
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/go-kit/kit/metrics/influx"
+	"github.com/go-kit/kit/log"
+	influxdb "github.com/influxdata/influxdb/client/v2"
+
+	"github.com/uber/jaeger-lib/metrics/go-kit"
+)
+
+func TestCounter(t *testing.T) {
+	in := influx.New(map[string]string{}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
+	inf := NewFactory(in)
+	wf := xkit.Wrap("namespace", inf)
+
+	c := wf.Counter("gokit.infl-counter", map[string]string{"label": "val1"})
+	c.Inc(7)
+
+	assert.Contains(t, reportToString(in), "namespace.gokit.infl-counter,label=val1 count=7")
+}
+
+func TestGauge(t *testing.T) {
+	in := influx.New(map[string]string{}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
+	inf := NewFactory(in)
+	wf := xkit.Wrap("namespace", inf)
+
+	g := wf.Gauge("gokit.infl-gauge", map[string]string{"x": "y"})
+	g.Update(42)
+
+	assert.Contains(t, reportToString(in), "namespace.gokit.infl-gauge,x=y value=42")
+}
+
+func TestTimer(t *testing.T) {
+	in := influx.New(map[string]string{}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
+	inf := NewFactory(in)
+	wf := xkit.Wrap("namespace", inf)
+
+	timer := wf.Timer("gokit.infl-timer", map[string]string{"x": "y"})
+	timer.Record(time.Second * 1)
+	timer.Record(time.Second * 1)
+	timer.Record(time.Second * 10)
+
+	assert.Contains(t, reportToString(in), "namespace.gokit.infl-timer,x=y p50=1,p90=10,p95=10,p99=10")
+}
+
+func TestWrapperNamespaces(t *testing.T) {
+	in := influx.New(map[string]string{}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
+	inf := NewFactory(in)
+	wf := xkit.Wrap("namespace", inf)
+
+	wf = wf.Namespace("bar", map[string]string{"bar_tag": "bar_tag"})
+
+	c := wf.Counter("gokit.prom-wrapped-counter", map[string]string{"x": "y"})
+	c.Inc(42)
+
+	assert.Contains(t, reportToString(in), "namespace.bar.gokit.prom-wrapped-counter,bar_tag=bar_tag,x=y count=42")
+}
+
+func TestCapabilities(t *testing.T) {
+	in := influx.New(map[string]string{}, influxdb.BatchPointsConfig{}, log.NewNopLogger())
+	inf := NewFactory(in)
+
+	assert.True(t, inf.Capabilities().Tagging)
+}
+
+func reportToString(in *influx.Influx) string {
+	client := &bufWriter{}
+	in.WriteTo(client)
+	return client.buf.String()
+}
+
+type bufWriter struct {
+	buf bytes.Buffer
+}
+
+func (w *bufWriter) Write(bp influxdb.BatchPoints) error {
+	for _, p := range bp.Points() {
+		fmt.Fprintf(&w.buf, p.String()+"\n")
+	}
+	return nil
+}


### PR DESCRIPTION
Adds support for reporting metrics to InfluxDB.

I used existing support for go-kit metrics.

For now it's not possible to specify histogram buckets because they are [hardcoded in go-kit](https://github.com/go-kit/kit/blob/master/metrics/influx/influx.go#L149).