### PR TITLE
Add a Jaeger client logger wrapper around go-kit logger

### DIFF
--- a/client/log/go-kit/logger.go
+++ b/client/log/go-kit/logger.go
@@ -20,26 +20,44 @@ import (
 	"github.com/go-kit/kit/log/level"
 )
 
+// LoggerOption sets a parameter for the StdlibAdapter.
+type LoggerOption func(*logger)
+
+// MessageKey sets the key for the actual log message. By default, it's "msg".
+func MessageKey(key string) LoggerOption {
+	return func(a *logger) { a.messageKey = key }
+}
+
 // logger wraps a go-kit logger instance in a Jaeger client compatible one.
 type logger struct {
 	infoLogger  log.Logger
 	errorLogger log.Logger
+
+	messageKey string
 }
 
 // NewLogger creates a new Jaeger client logger from a go-kit one.
-func NewLogger(l log.Logger) *logger {
-	return &logger{
-		infoLogger:  level.Info(l),
-		errorLogger: level.Error(l),
+func NewLogger(kitlogger log.Logger, options ...LoggerOption) *logger {
+	l := &logger{
+		infoLogger:  level.Info(kitlogger),
+		errorLogger: level.Error(kitlogger),
+
+		messageKey: "msg",
 	}
+
+	for _, option := range options {
+		option(l)
+	}
+
+	return l
 }
 
 // Error implements the github.com/uber/jaeger-client-go/log.Logger interface.
 func (l *logger) Error(msg string) {
-	l.errorLogger.Log("msg", msg)
+	l.errorLogger.Log(l.messageKey, msg)
 }
 
 // Infof implements the github.com/uber/jaeger-client-go/log.Logger interface.
 func (l *logger) Infof(msg string, args ...interface{}) {
-	l.infoLogger.Log("msg", fmt.Sprintf(msg, args...))
+	l.infoLogger.Log(l.messageKey, fmt.Sprintf(msg, args...))
 }

--- a/client/log/go-kit/logger.go
+++ b/client/log/go-kit/logger.go
@@ -16,11 +16,12 @@ package xkit
 
 import (
 	"fmt"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 )
 
-// LoggerOption sets a parameter for the StdlibAdapter.
+// LoggerOption sets a parameter for the Logger.
 type LoggerOption func(*Logger)
 
 // MessageKey sets the key for the actual log message. By default, it's "msg".

--- a/client/log/go-kit/logger.go
+++ b/client/log/go-kit/logger.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xkit
+
+import (
+	"fmt"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+// logger wraps a go-kit logger instance in a Jaeger client compatible one.
+type logger struct {
+	infoLogger  log.Logger
+	errorLogger log.Logger
+}
+
+// NewLogger creates a new Jaeger client logger from a go-kit one.
+func NewLogger(l log.Logger) *logger {
+	return &logger{
+		infoLogger:  level.Info(l),
+		errorLogger: level.Error(l),
+	}
+}
+
+// Error implements the github.com/uber/jaeger-client-go/log.Logger interface.
+func (l *logger) Error(msg string) {
+	l.errorLogger.Log("msg", msg)
+}
+
+// Infof implements the github.com/uber/jaeger-client-go/log.Logger interface.
+func (l *logger) Infof(msg string, args ...interface{}) {
+	l.infoLogger.Log("msg", fmt.Sprintf(msg, args...))
+}

--- a/client/log/go-kit/logger.go
+++ b/client/log/go-kit/logger.go
@@ -21,15 +21,15 @@ import (
 )
 
 // LoggerOption sets a parameter for the StdlibAdapter.
-type LoggerOption func(*logger)
+type LoggerOption func(*Logger)
 
 // MessageKey sets the key for the actual log message. By default, it's "msg".
 func MessageKey(key string) LoggerOption {
-	return func(a *logger) { a.messageKey = key }
+	return func(l *Logger) { l.messageKey = key }
 }
 
-// logger wraps a go-kit logger instance in a Jaeger client compatible one.
-type logger struct {
+// Logger wraps a go-kit logger instance in a Jaeger client compatible one.
+type Logger struct {
 	infoLogger  log.Logger
 	errorLogger log.Logger
 
@@ -37,8 +37,8 @@ type logger struct {
 }
 
 // NewLogger creates a new Jaeger client logger from a go-kit one.
-func NewLogger(kitlogger log.Logger, options ...LoggerOption) *logger {
-	l := &logger{
+func NewLogger(kitlogger log.Logger, options ...LoggerOption) *Logger {
+	logger := &Logger{
 		infoLogger:  level.Info(kitlogger),
 		errorLogger: level.Error(kitlogger),
 
@@ -46,18 +46,18 @@ func NewLogger(kitlogger log.Logger, options ...LoggerOption) *logger {
 	}
 
 	for _, option := range options {
-		option(l)
+		option(logger)
 	}
 
-	return l
+	return logger
 }
 
 // Error implements the github.com/uber/jaeger-client-go/log.Logger interface.
-func (l *logger) Error(msg string) {
+func (l *Logger) Error(msg string) {
 	l.errorLogger.Log(l.messageKey, msg)
 }
 
 // Infof implements the github.com/uber/jaeger-client-go/log.Logger interface.
-func (l *logger) Infof(msg string, args ...interface{}) {
+func (l *Logger) Infof(msg string, args ...interface{}) {
 	l.infoLogger.Log(l.messageKey, fmt.Sprintf(msg, args...))
 }

--- a/client/log/go-kit/logger_test.go
+++ b/client/log/go-kit/logger_test.go
@@ -25,3 +25,12 @@ func TestLogger_Error(t *testing.T) {
 
 	assert.Equal(t, "level=error msg=\"Something really bad happened\"\n", buf.String())
 }
+
+func TestMessageKey(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewLogger(log.NewLogfmtLogger(buf), MessageKey("message"))
+
+	logger.Error("Something really bad happened")
+
+	assert.Equal(t, "level=error message=\"Something really bad happened\"\n", buf.String())
+}

--- a/client/log/go-kit/logger_test.go
+++ b/client/log/go-kit/logger_test.go
@@ -1,0 +1,27 @@
+package xkit
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogger_Infof(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewLogger(log.NewLogfmtLogger(buf))
+
+	logger.Infof("Formatted %s", "string")
+
+	assert.Equal(t, "level=info msg=\"Formatted string\"\n", buf.String())
+}
+
+func TestLogger_Error(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewLogger(log.NewLogfmtLogger(buf))
+
+	logger.Error("Something really bad happened")
+
+	assert.Equal(t, "level=error msg=\"Something really bad happened\"\n", buf.String())
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 8ca2ebd4305a4aaead18ee8cc5a84da42e95c202d53c1bd78d11436aeb8be8e4
-updated: 2017-09-12T23:48:13.239754093+02:00
+updated: 2017-09-20T01:48:48.588894144+02:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -17,6 +17,7 @@ imports:
   version: a9ca6725cbbea455e61c6bc8a1ed28e81eb3493b
   subpackages:
   - log
+  - log/level
   - metrics
   - metrics/expvar
   - metrics/generic


### PR DESCRIPTION
Fixes uber/jaeger-client-go#200

This is my first contribution to any Uber software, I'm not particularly familiar with your code guides (tried to follow some practices based on code and contrib guide though), so think of it as a first draft and shoot at it.